### PR TITLE
Removed the unnecessary white space from top

### DIFF
--- a/style.css
+++ b/style.css
@@ -205,7 +205,6 @@ header {
   background-size: cover;
   position: relative;
   min-height: 110vh;
-  margin-top: 5%;
   height: 110vh;
   display: flex;
   align-items: center;


### PR DESCRIPTION
There is unnecessary white space at the top of the page which can be seen behind the navbar, I've removed it by removing the margin.

Before -
![image](https://user-images.githubusercontent.com/89779447/194747102-ff064810-8453-47ae-b0c4-ddb9a382f760.png)

After -
![image](https://user-images.githubusercontent.com/89779447/194747118-0ec26215-26d8-4330-b35e-fce8d8c491e0.png)
